### PR TITLE
Removed the named field

### DIFF
--- a/gwaihir/gui/gui.py
+++ b/gwaihir/gui/gui.py
@@ -3763,7 +3763,7 @@ class Interface():
             print("Running pynx-cdi-analysis.py *LLK* modes=1")
             print(f"Output in {folder}/modes_gui.h5")
             os.system(
-                "{s}/pynx-cdi-analysis.py {}/*LLK* modes=1 modes_output={}/modes_gui.h5".format(
+                "{}/pynx-cdi-analysis.py {}/*LLK* modes=1 modes_output={}/modes_gui.h5".format(
                     quote(self.path_script),
                     quote(folder),
                     quote(folder),


### PR DESCRIPTION
The format string in line number 3766 has a named field which is not provided by the keyword arguments. This would have raised a KeyError. So fixed it.